### PR TITLE
Feature: Add customization options for host and port

### DIFF
--- a/src/mcp_server_obsidian_omnisearch/__init__.py
+++ b/src/mcp_server_obsidian_omnisearch/__init__.py
@@ -1,17 +1,1 @@
-from .server import serve
 
-
-def main():
-    import sys
-    import asyncio
-
-    if len(sys.argv) < 2:
-        print("Usage: python server.py <obsidian_vault_path>")
-        sys.exit(1)
-
-    obsidian_vault_path = sys.argv[1]
-    asyncio.run(serve(obsidian_vault_path))
-
-
-if __name__ == "__main__":
-    main()

--- a/src/mcp_server_obsidian_omnisearch/__main__.py
+++ b/src/mcp_server_obsidian_omnisearch/__main__.py
@@ -1,5 +1,17 @@
-# __main__.py
+from .server import serve
 
-from mcp_server_obsidian_omnisearch import main
 
-main()
+def main():
+    import sys
+    import asyncio
+
+    if len(sys.argv) < 2:
+        print("Usage: python server.py <obsidian_vault_path>")
+        sys.exit(1)
+
+    obsidian_vault_path = sys.argv[1]
+    asyncio.run(serve(obsidian_vault_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server_obsidian_omnisearch/__main__.py
+++ b/src/mcp_server_obsidian_omnisearch/__main__.py
@@ -1,3 +1,4 @@
+import os
 from .server import serve
 
 
@@ -10,7 +11,12 @@ def main():
         sys.exit(1)
 
     obsidian_vault_path = sys.argv[1]
-    asyncio.run(serve(obsidian_vault_path))
+    host = os.environ.get("OBSIDIAN_HOST", "localhost")
+    port = os.environ.get("OBSIDIAN_PORT", "51361")
+
+    base_path = os.environ.get("BASE_PATH", None)
+    
+    asyncio.run(serve(host, port, base_path=base_path))
 
 
 if __name__ == "__main__":

--- a/src/mcp_server_obsidian_omnisearch/server.py
+++ b/src/mcp_server_obsidian_omnisearch/server.py
@@ -4,7 +4,7 @@ import requests
 import os
 
 
-def serve(obsidian_vault_path: str):
+def serve(host: str, port: str, base_path: str = None):
     mcp = FastMCP("obsidian-omnisearch", log_level="ERROR")
 
     @mcp.tool()
@@ -24,7 +24,7 @@ def serve(obsidian_vault_path: str):
                 f"<title>{item['basename']}</title>\n"
                 f"<excerpt>{item['excerpt']}</excerpt>\n"
                 f"<score>{item['score']}</score>\n"
-                f"<filepath>{os.path.join(obsidian_vault_path, item['path'].lstrip('/'))}</filepath>"
+                f"<filepath>{os.path.join(base_path or "/", item['path'].lstrip('/'))}</filepath>"
                 for item in sorted_results
             ]
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor entry point logic from `__init__.py` to `__main__.py`

- Add environment variable support for host and port configuration

- Add optional `base_path` parameter for customizable vault path

- Update `serve()` function signature to accept host, port, base_path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["__init__.py"] -->|"move main logic"| B["__main__.py"]
  B -->|"read env vars"| C["OBSIDIAN_HOST<br/>OBSIDIAN_PORT<br/>BASE_PATH"]
  C -->|"pass to serve()"| D["server.py<br/>serve function"]
  D -->|"use base_path"| E["filepath construction"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Remove entry point logic from __init__.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcp_server_obsidian_omnisearch/__init__.py

<ul><li>Removed all content including <code>main()</code> function and entry point logic<br> <li> Removed import of <code>serve</code> function<br> <li> File now empty as functionality moved to <code>__main__.py</code></ul>


</details>


  </td>
  <td><a href="https://github.com/anpigon/mcp-server-obsidian-omnisearch/pull/7/files#diff-1f8529b372f3e5b0d37dc78f0cdaa416c54e039835f6b4174a55a95eeb1b8625">+0/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__main__.py</strong><dd><code>Implement main entry point with env var support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcp_server_obsidian_omnisearch/__main__.py

<ul><li>Replaced simple import-based entry point with full <code>main()</code> function <br>implementation<br> <li> Added environment variable reading for <code>OBSIDIAN_HOST</code>, <code>OBSIDIAN_PORT</code>, <br>and <code>BASE_PATH</code><br> <li> Updated <code>serve()</code> call to pass host, port, and base_path parameters<br> <li> Added direct import of <code>serve</code> function from server module</ul>


</details>


  </td>
  <td><a href="https://github.com/anpigon/mcp-server-obsidian-omnisearch/pull/7/files#diff-55ed2ea91a68e46a68aaec7cc3fb1c673f92651b3404db8ab678ab4492e27d37">+21/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Update serve function signature for host/port/base_path</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/mcp_server_obsidian_omnisearch/server.py

<ul><li>Changed <code>serve()</code> function signature from <code>serve(obsidian_vault_path: </code><br><code>str)</code> to <code>serve(host: str, port: str, base_path: str = None)</code><br> <li> Updated filepath construction to use <code>base_path or "/"</code> instead of <br><code>obsidian_vault_path</code><br> <li> Function now accepts host and port parameters for server configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/anpigon/mcp-server-obsidian-omnisearch/pull/7/files#diff-b8adb395a1859435488569705cc86274d60d3b9911112a247752728c671fc55f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 애플리케이션 시작 방식을 재구성했습니다. 이제 명령줄에서 Obsidian 볼트 경로를 인자로 전달해야 합니다.
  * 환경 변수(호스트, 포트, 기본 경로)를 통한 설정 지원이 추가되었습니다.
  * 서버 구성 방식이 업데이트되어 더 유연한 배포가 가능합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->